### PR TITLE
Fix: message shown when there are no motos corrected

### DIFF
--- a/frontend/src/components/Motos.vue
+++ b/frontend/src/components/Motos.vue
@@ -7,7 +7,7 @@
       <div id="lista_motos" v-if="available_motos.length>0" class="center-screen">
         <div class="row">
           <div class="col-sm">License plate</div>
-          <div class="col-sm">Distance</div>
+          <div class="col-sm">Distance (in meters)</div>
           <div class="col-sm">Type</div>
         </div>
         <button v-for="item in available_motos" :key="item.matricula" type="button" class="list-group-item list-group-item-action"  @click="reserveMoto()">
@@ -20,7 +20,7 @@
       </div>
         <!-- Mensaje si no hay motos -->
         <div id="no_motos" v-if="available_motos.length===0" class="center-screen">
-          <p>There are no motos availables</p>
+          <p>{{ message_no_motos_available }}</p>
         </div>
     </div>
   </div>
@@ -41,7 +41,8 @@ export default {
       },
       displayed_motos: {
         items: []
-      }
+      },
+      message_no_motos_available: 'There are no motos available'
     }
   },
   created () {


### PR DESCRIPTION
The message was changed.
It is indicated that the distance is in meters.