### PR TITLE
Style: Make uniform colour background for login and register pages

### DIFF
--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -1,31 +1,34 @@
 <template>
-  <div class="jumbotron">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-8 offset-sm-2">
-          <div>
-            <h2>Log in</h2>
-            <form @submit.prevent="handleSubmit">
-              <div class="form-group">
-                <label for="email">Email</label>
-                <input type="email" v-model="user.email" id="email" name="email" class="form-control" :class="{ 'is-invalid': submitted && $v.user.email.$error }" />
-                <div v-if="submitted && $v.user.email.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.email.required">Email is required</span>
-                  <span v-if="!$v.user.email.email">Email is invalid</span>
+  <div id="wholePage">
+    <!-- Divisor que ocupa solo lo necesario para cubrir la info del login-->
+    <div class="jumbotron">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-8 offset-sm-2">
+            <div>
+              <h2>Log in</h2>
+              <form @submit.prevent="handleSubmit">
+                <div class="form-group">
+                  <label for="email">Email</label>
+                  <input type="email" v-model="user.email" id="email" name="email" class="form-control" :class="{ 'is-invalid': submitted && $v.user.email.$error }" />
+                  <div v-if="submitted && $v.user.email.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.email.required">Email is required</span>
+                    <span v-if="!$v.user.email.email">Email is invalid</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label for="password">Password</label>
-                <input type="password" v-model="user.password" id="password" name="password" class="form-control" :class="{ 'is-invalid': submitted && $v.user.password.$error }" />
-                <div v-if="submitted && $v.user.password.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.password.required">Password is required</span>
-                  <span v-if="!$v.user.password.minLength">Password must be at least 6 characters</span>
+                <div class="form-group">
+                  <label for="password">Password</label>
+                  <input type="password" v-model="user.password" id="password" name="password" class="form-control" :class="{ 'is-invalid': submitted && $v.user.password.$error }" />
+                  <div v-if="submitted && $v.user.password.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.password.required">Password is required</span>
+                    <span v-if="!$v.user.password.minLength">Password must be at least 6 characters</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <button class="btn btn-primary">Log in</button>
-              </div>
-            </form>
+                <div class="form-group">
+                  <button class="btn btn-primary">Log in</button>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>
@@ -91,5 +94,18 @@ export default {
 </script>
 
 <style scoped>
+#wholePage
+  {
+  position:fixed;
+  padding:0;
+  margin:0;
 
+  top:0;
+  left:0;
+
+  width: 100%;
+  height: 100%;
+
+  background-color: #e9ecef;
+  }
 </style>

--- a/frontend/src/components/Registration.vue
+++ b/frontend/src/components/Registration.vue
@@ -1,61 +1,63 @@
 <template>
-  <div class="jumbotron">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-8 offset-sm-2">
-          <div>
-            <h2>Register Form</h2>
-            <form @submit.prevent="handleSubmit">
-              <div class="form-group">
-                <label for="completeName">Complete Name</label>
-                <input type="text" v-model="user.completeName" id="completeName" name="CompleteName" class="form-control" :class="{ 'is-invalid': submitted && $v.user.completeName.$error }" />
-                <div v-if="submitted && !$v.user.completeName.required" class="invalid-feedback">Complete Name is required</div>
-              </div>
-              <div class="form-group">
-                <label for="dniNie">DNI/NIE</label>
-                <input type="text" v-model="user.dniNie" id="dniNie" name="dniNie" class="form-control" :class="{ 'is-invalid': submitted && $v.user.dniNie.$error }" />
-                <div v-if="submitted && $v.user.dniNie.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.dniNie.required">DNI/NIE is required</span>
-                  <span v-if="!$v.user.dniNie.minLength">DNI/NIE must be at least 8 characters</span>
+  <div id="wholePage">
+    <div class="jumbotron">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-8 offset-sm-2">
+            <div>
+              <h2>Register Form</h2>
+              <form @submit.prevent="handleSubmit">
+                <div class="form-group">
+                  <label for="completeName">Complete Name</label>
+                  <input type="text" v-model="user.completeName" id="completeName" name="CompleteName" class="form-control" :class="{ 'is-invalid': submitted && $v.user.completeName.$error }" />
+                  <div v-if="submitted && !$v.user.completeName.required" class="invalid-feedback">Complete Name is required</div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label for="iban">IBAN</label>
-                <input type="text" v-model="user.iban" id="iban" name="iban" class="form-control" :class="{ 'is-invalid': submitted && $v.user.iban.$error }" />
-                <div v-if="submitted && $v.user.iban.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.iban.required">IBAN is required</span>
-                  <span v-if="!$v.user.iban.minLength">IBAN must be at least 5 characters</span>
-                  <span v-if="!$v.user.iban.maxLength">IBAN must be no more than 34 characters</span>
+                <div class="form-group">
+                  <label for="dniNie">DNI/NIE</label>
+                  <input type="text" v-model="user.dniNie" id="dniNie" name="dniNie" class="form-control" :class="{ 'is-invalid': submitted && $v.user.dniNie.$error }" />
+                  <div v-if="submitted && $v.user.dniNie.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.dniNie.required">DNI/NIE is required</span>
+                    <span v-if="!$v.user.dniNie.minLength">DNI/NIE must be at least 8 characters</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label for="email">Email</label>
-                <input type="email" v-model="user.email" id="email" name="email" class="form-control" :class="{ 'is-invalid': submitted && $v.user.email.$error }" />
-                <div v-if="submitted && $v.user.email.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.email.required">Email is required</span>
-                  <span v-if="!$v.user.email.email">Email is invalid</span>
+                <div class="form-group">
+                  <label for="iban">IBAN</label>
+                  <input type="text" v-model="user.iban" id="iban" name="iban" class="form-control" :class="{ 'is-invalid': submitted && $v.user.iban.$error }" />
+                  <div v-if="submitted && $v.user.iban.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.iban.required">IBAN is required</span>
+                    <span v-if="!$v.user.iban.minLength">IBAN must be at least 5 characters</span>
+                    <span v-if="!$v.user.iban.maxLength">IBAN must be no more than 34 characters</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label for="password">Password</label>
-                <input type="password" v-model="user.password" id="password" name="password" class="form-control" :class="{ 'is-invalid': submitted && $v.user.password.$error }" />
-                <div v-if="submitted && $v.user.password.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.password.required">Password is required</span>
-                  <span v-if="!$v.user.password.minLength">Password must be at least 6 characters</span>
+                <div class="form-group">
+                  <label for="email">Email</label>
+                  <input type="email" v-model="user.email" id="email" name="email" class="form-control" :class="{ 'is-invalid': submitted && $v.user.email.$error }" />
+                  <div v-if="submitted && $v.user.email.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.email.required">Email is required</span>
+                    <span v-if="!$v.user.email.email">Email is invalid</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <label for="confirmPassword">Confirm Password</label>
-                <input type="password" v-model="user.confirmPassword" id="confirmPassword" name="confirmPassword" class="form-control" :class="{ 'is-invalid': submitted && $v.user.confirmPassword.$error }" />
-                <div v-if="submitted && $v.user.confirmPassword.$error" class="invalid-feedback">
-                  <span v-if="!$v.user.confirmPassword.required">Confirm Password is required</span>
-                  <span v-else-if="!$v.user.confirmPassword.sameAsPassword">Passwords must match</span>
+                <div class="form-group">
+                  <label for="password">Password</label>
+                  <input type="password" v-model="user.password" id="password" name="password" class="form-control" :class="{ 'is-invalid': submitted && $v.user.password.$error }" />
+                  <div v-if="submitted && $v.user.password.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.password.required">Password is required</span>
+                    <span v-if="!$v.user.password.minLength">Password must be at least 6 characters</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group">
-                <button class="btn btn-primary">Register</button>
-              </div>
-            </form>
+                <div class="form-group">
+                  <label for="confirmPassword">Confirm Password</label>
+                  <input type="password" v-model="user.confirmPassword" id="confirmPassword" name="confirmPassword" class="form-control" :class="{ 'is-invalid': submitted && $v.user.confirmPassword.$error }" />
+                  <div v-if="submitted && $v.user.confirmPassword.$error" class="invalid-feedback">
+                    <span v-if="!$v.user.confirmPassword.required">Confirm Password is required</span>
+                    <span v-else-if="!$v.user.confirmPassword.sameAsPassword">Passwords must match</span>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <button class="btn btn-primary">Register</button>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>
@@ -125,5 +127,18 @@ export default {
 </script>
 
 <style scoped>
+#wholePage
+  {
+    position:fixed;
+    padding:0;
+    margin:0;
 
+    top:0;
+    left:0;
+
+    width: 100%;
+    height: 100%;
+
+    background-color: #e9ecef;
+  }
 </style>


### PR DESCRIPTION
Lo que he hecho ha sido crear un divisor que incluyera el _jumbotron_, que es lo que antes se veía con fondo azulado.
A este divisor le he puesto un color de background igual que el del jumbotron, #e9ecef, y he hecho que este divisor que contiene todo, ocupe toda la pantalla (código del style en css).

Había intentado hacer el jumbotron de toda la página, pero si le añadía márgenes, se veía el fondo blanco de nuevo.